### PR TITLE
Fix micro typo in python example

### DIFF
--- a/doc/build/orm/session_state_management.rst
+++ b/doc/build/orm/session_state_management.rst
@@ -350,7 +350,7 @@ Another example of unexpected state::
 
     >>> a1 = Address(id=existing_a1.id, user_id=u1.id)
     >>> assert a1.user is None
-    >>> True
+    True
     >>> a1 = session.merge(a1)
     >>> session.commit()
     sqlalchemy.exc.IntegrityError: (IntegrityError) address.user_id


### PR DESCRIPTION
Micro typo fix, `True` is not our input but our output.